### PR TITLE
Added kotlin helper class to support mockito any matchers

### DIFF
--- a/test/dependency/src/main/java/com/b2msolutions/dependency/Dependency.java
+++ b/test/dependency/src/main/java/com/b2msolutions/dependency/Dependency.java
@@ -9,5 +9,3 @@ import java.lang.annotation.Target;
 @Target({ElementType.FIELD})
 public @interface Dependency {
 }
-
-

--- a/test/src/main/java/com/b2msolutions/test/KotlinHelper.kt
+++ b/test/src/main/java/com/b2msolutions/test/KotlinHelper.kt
@@ -1,0 +1,34 @@
+package com.b2msolutions.test
+
+import org.mockito.Mockito
+
+abstract class KotlinHelper {
+    companion object {
+        fun setStaticField(item: Any, propName: String, value: Any?) {
+            val field = item::class.java.getDeclaredField(propName)
+            field.isAccessible = true
+            field.set(item, value)
+        }
+
+        fun getStaticField(item: Any, propName: String): Any {
+            val field = item::class.java.getDeclaredField(propName)
+            field.isAccessible = true
+            return field.get(item)
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        fun <T> uninitialized(): T = null as T
+
+        fun <T> eq(value: T): T {
+            return Mockito.eq(value) ?: uninitialized()
+        }
+
+        fun <T> any(type: Class<T>): T {
+            return Mockito.any(type) ?: uninitialized()
+        }
+
+        fun <T> anyObject(): T {
+            return Mockito.any<T>() ?: uninitialized()
+        }
+    }
+}


### PR DESCRIPTION
allows to use `any(PackageInfo::class.java)`

by default any will return null, that will fail kotlin type check as argument is not nullable