### PR TITLE
fix kotlin eq returning null for value based types

### DIFF
--- a/test/src/main/java/com/b2msolutions/test/KotlinHelper.kt
+++ b/test/src/main/java/com/b2msolutions/test/KotlinHelper.kt
@@ -20,7 +20,7 @@ abstract class KotlinHelper {
         fun <T> uninitialized(): T = null as T
 
         fun <T> eq(value: T): T {
-            return Mockito.eq(value) ?: uninitialized()
+            return Mockito.eq(value) ?: value ?: uninitialized()
         }
 
         fun <T> any(type: Class<T>): T {


### PR DESCRIPTION
Kotlin verify that any non null argument should have a value, but mokito `eq` returns null.
The previous solution worked for any object based type, but didn`t for array